### PR TITLE
Tighten path-traversal guards (closes #5)

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -9,6 +9,7 @@ import { Doc, type Adapter, type Block, type Command } from "@artefact-editor/co
 import { htmlAdapter, previewBridgeScript } from "@artefact-editor/adapter-html";
 import { imageTemplateAdapter } from "@artefact-editor/adapter-image-template";
 import { FsProjectFiles } from "./projectFiles.js";
+import { isInside } from "./paths.js";
 
 interface ManifestMeta {
   name?: string;
@@ -387,7 +388,7 @@ app.get("/preview/:id/*", async (c) => {
   let rel = url.pathname.replace(new RegExp(`^/preview/${id}/?`), "");
   if (!rel) rel = p.entry;
   const abs = resolve(p.root, rel);
-  if (!abs.startsWith(resolve(p.root))) {
+  if (!isInside(resolve(p.root), abs)) {
     return c.text("Forbidden", 403);
   }
   try {
@@ -429,7 +430,7 @@ if (webDistExists) {
     let rel = url.pathname.replace(/^\//, "");
     if (!rel) rel = "index.html";
     const abs = resolve(webDist, rel);
-    if (!abs.startsWith(resolve(webDist))) return c.text("Forbidden", 403);
+    if (!isInside(resolve(webDist), abs)) return c.text("Forbidden", 403);
     let buf: Buffer;
     try {
       buf = await readFile(abs);

--- a/apps/cli/src/paths.ts
+++ b/apps/cli/src/paths.ts
@@ -1,0 +1,6 @@
+import { relative, isAbsolute } from "node:path";
+
+export function isInside(root: string, abs: string): boolean {
+  const rel = relative(root, abs);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}

--- a/apps/cli/src/projectFiles.ts
+++ b/apps/cli/src/projectFiles.ts
@@ -1,13 +1,19 @@
 import { readFile, writeFile, readdir, stat, rename, mkdir } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
 import type { ProjectFiles } from "@artefact-editor/core";
+import { isInside } from "./paths.js";
 
 export class FsProjectFiles implements ProjectFiles {
-  constructor(private readonly root: string) {}
+  private readonly resolvedRoot: string;
+
+  constructor(private readonly root: string) {
+    this.resolvedRoot = resolve(root);
+  }
 
   private resolve(file: string): string {
-    const abs = resolve(this.root, file);
-    if (!abs.startsWith(resolve(this.root))) {
+    const abs = resolve(this.resolvedRoot, file);
+    if (!isInside(this.resolvedRoot, abs)) {
       throw new Error(`Path escapes project root: ${file}`);
     }
     return abs;
@@ -24,7 +30,7 @@ export class FsProjectFiles implements ProjectFiles {
   async write(file: string, contents: string): Promise<void> {
     const abs = this.resolve(file);
     await mkdir(dirname(abs), { recursive: true });
-    const tmp = abs + ".tmp";
+    const tmp = `${abs}.${randomUUID()}.tmp`;
     await writeFile(tmp, contents, "utf8");
     await rename(tmp, abs);
   }
@@ -47,7 +53,7 @@ export class FsProjectFiles implements ProjectFiles {
   }
 
   rootPath(): string {
-    return resolve(this.root);
+    return this.resolvedRoot;
   }
 
   abs(file: string): string {


### PR DESCRIPTION
## Summary

- New `apps/cli/src/paths.ts` exports `isInside(root, abs)` using `path.relative` — rejects when the relative path starts with `..` or is absolute.
- Three sites now use it: preview route (`apps/cli/src/index.ts`), web-dist fallback route, and `FsProjectFiles.resolve`.
- `FsProjectFiles` now resolves the root once in the constructor; previous code re-resolved on every call.
- `FsProjectFiles.write` tmp suffix is now `${abs}.${randomUUID()}.tmp` instead of a fixed `${abs}.tmp` — concurrent saves no longer collide on the tmp file.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Unit test on `isInside` — 9 cases including `/root-evil` (the reported bypass), `..` resolution, and same-prefix sibling paths
- [x] Browser smoke: legitimate preview paths return 200; missing files 404; `..` traversal in the URL falls through to the SPA handler (Hono normalises `..` before our handler sees it — `isInside` is the defence-in-depth layer)

Closes #5.