### PR TITLE
Dedupe adapter-html helpers; replace dir-probe with isDirectory (closes #6)

### DIFF
--- a/apps/cli/src/projectFiles.ts
+++ b/apps/cli/src/projectFiles.ts
@@ -52,6 +52,15 @@ export class FsProjectFiles implements ProjectFiles {
     }
   }
 
+  async isDirectory(path: string): Promise<boolean> {
+    try {
+      const s = await stat(this.resolve(path));
+      return s.isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
   rootPath(): string {
     return this.resolvedRoot;
   }

--- a/packages/adapter-html/src/inject.ts
+++ b/packages/adapter-html/src/inject.ts
@@ -1,3 +1,5 @@
+import { STYLE_PROPS } from "./styleProps.js";
+
 /**
  * Script injected into the preview iframe to bridge with the editor.
  *
@@ -26,14 +28,7 @@ export const previewBridgeScript = `
   document.head.appendChild(aeStyle);
 
   var selectedEl = null;
-  var STYLE_KEYS = [
-    'color', 'font-size', 'font-weight', 'font-family', 'text-align', 'letter-spacing', 'line-height',
-    'top', 'left', 'right', 'bottom',
-    'width', 'height',
-    'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
-    'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
-    'transform', 'opacity', 'z-index'
-  ];
+  var STYLE_KEYS = ${JSON.stringify(STYLE_PROPS)};
   function postSelectedStyles() {
     if (!selectedEl) return;
     var cs = window.getComputedStyle(selectedEl);

--- a/packages/adapter-html/src/load.ts
+++ b/packages/adapter-html/src/load.ts
@@ -8,6 +8,8 @@ import {
 } from "@artefact-editor/core";
 import { findOneMatching } from "./selector.js";
 import { findScriptVar } from "./scriptVar.js";
+import { escapeRegex } from "./regex.js";
+import { STYLE_PROPS } from "./styleProps.js";
 
 const TEXT_NODE = "#text";
 
@@ -38,10 +40,6 @@ function findCssVar(css: string, varName: string): string {
   const m = re.exec(css);
   if (!m) throw new Error(`CSS variable not found: ${varName}`);
   return m[2]!.trim();
-}
-
-function escapeRegex(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function readSelectorBlock(
@@ -153,32 +151,6 @@ export async function loadProject(files: ProjectFiles): Promise<{
       // Live values are read from the iframe; pending edits flow through normal
       // setProperty commands and the adapter upserts them into the element's
       // inline style attribute on save.
-      const STYLE_PROPS = [
-        "color",
-        "font-size",
-        "font-weight",
-        "font-family",
-        "text-align",
-        "letter-spacing",
-        "line-height",
-        "top",
-        "left",
-        "right",
-        "bottom",
-        "width",
-        "height",
-        "margin-top",
-        "margin-right",
-        "margin-bottom",
-        "margin-left",
-        "padding-top",
-        "padding-right",
-        "padding-bottom",
-        "padding-left",
-        "transform",
-        "opacity",
-        "z-index",
-      ];
       for (const p of STYLE_PROPS) {
         descriptors.push({ key: `style.${p}`, type: "string" });
       }

--- a/packages/adapter-html/src/mutate.ts
+++ b/packages/adapter-html/src/mutate.ts
@@ -5,6 +5,7 @@ import {
   getElementSourceLocation,
 } from "./selector.js";
 import { locateScriptVarValue } from "./scriptVar.js";
+import { escapeRegex } from "./regex.js";
 
 interface PendingEdit {
   start: number;
@@ -28,10 +29,6 @@ function decodeHtmlEntities(s: string): string {
 
 function escapeAttr(value: string): string {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
-}
-
-function escapeRegex(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function applyEdits(source: string, edits: PendingEdit[]): string {
@@ -257,9 +254,9 @@ async function listFilesRecursive(
       acc.push(path);
       continue;
     }
-    // Probe as directory: list() returns [] for non-dirs, so cheap to recurse.
-    const sub = await files.list(path);
-    if (sub.length > 0) await listFilesRecursive(files, path, acc);
+    if (await files.isDirectory(path)) {
+      await listFilesRecursive(files, path, acc);
+    }
   }
 }
 

--- a/packages/adapter-html/src/regex.ts
+++ b/packages/adapter-html/src/regex.ts
@@ -1,0 +1,3 @@
+export function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/adapter-html/src/scriptVar.ts
+++ b/packages/adapter-html/src/scriptVar.ts
@@ -8,9 +8,7 @@
  * (deferred to a future adapter that imports recast/babel).
  */
 
-function escapeRegex(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
+import { escapeRegex } from "./regex.js";
 
 function declarationRegex(varName: string): RegExp {
   return new RegExp(

--- a/packages/adapter-html/src/styleProps.ts
+++ b/packages/adapter-html/src/styleProps.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical list of CSS properties exposed to the editor as style.* descriptors
+ * AND read live from the iframe's computed style. Both sides MUST agree on
+ * this list, so it lives in one place.
+ */
+export const STYLE_PROPS = [
+  "color",
+  "font-size",
+  "font-weight",
+  "font-family",
+  "text-align",
+  "letter-spacing",
+  "line-height",
+  "top",
+  "left",
+  "right",
+  "bottom",
+  "width",
+  "height",
+  "margin-top",
+  "margin-right",
+  "margin-bottom",
+  "margin-left",
+  "padding-top",
+  "padding-right",
+  "padding-bottom",
+  "padding-left",
+  "transform",
+  "opacity",
+  "z-index",
+] as const;
+
+export type StyleProp = (typeof STYLE_PROPS)[number];

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -7,6 +7,7 @@ export interface ProjectFiles {
   write(file: string, contents: string): Promise<void>;
   list(dir: string): Promise<string[]>;
   exists(file: string): Promise<boolean>;
+  isDirectory(path: string): Promise<boolean>;
 }
 
 export interface Adapter {


### PR DESCRIPTION
## Summary

- New `regex.ts` exports `escapeRegex` — `mutate.ts`, `load.ts`, and `scriptVar.ts` previously had three identical copies.
- New `styleProps.ts` exports `STYLE_PROPS`. `load.ts` uses it for synthetic `style.*` descriptors; `inject.ts` interpolates it into the preview-bridge script via `${JSON.stringify(STYLE_PROPS)}` so the iframe's `STYLE_KEYS` array can't drift from the editor.
- `ProjectFiles` gains `isDirectory(path)`. `mutate.ts`'s `listFilesRecursive` now uses it instead of probing every entry with a no-op `list()` (which threw `ENOTDIR` for files and was caught — wasted syscalls + exception).

## Test plan

- [x] `tsc --noEmit` clean across all workspaces
- [x] Build outputs verified — runtime-rendered bridge script contains the expected JSON array literal
- [x] Smoke test: text edit (`/api/projects/.../save` → headline persists) and style edit (`style.color` → inline `style="color: #ff0000"` upserted)

Closes #6.