### PR TITLE
Inspector/Timeline: extract FieldRow, tighten types (closes #8)

### DIFF
--- a/apps/web/src/components/FieldRow.tsx
+++ b/apps/web/src/components/FieldRow.tsx
@@ -1,0 +1,65 @@
+import { Input } from "./ui/input.js";
+import { Textarea } from "./ui/textarea.js";
+import { Label } from "./ui/label.js";
+
+type Kind = "text" | "color" | "number" | "textarea" | "enum";
+
+type Common = {
+  htmlId: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export type FieldRowProps =
+  | (Common & { kind: "text" | "color" | "textarea" })
+  | (Common & { kind: "number"; min?: number; max?: number; step?: number })
+  | (Common & { kind: "enum"; options: readonly string[] });
+
+export function FieldRow(props: FieldRowProps) {
+  const { htmlId, label, value, onChange, kind } = props;
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={htmlId}>{label}</Label>
+      {kind === "color" ? (
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            value={/^#[0-9a-fA-F]{6,8}$/.test(value) ? value : "#000000"}
+            onChange={(e) => onChange(e.target.value)}
+            className="h-9 w-12 cursor-pointer rounded border border-border bg-background"
+          />
+          <Input id={htmlId} value={value} onChange={(e) => onChange(e.target.value)} />
+        </div>
+      ) : kind === "textarea" ? (
+        <Textarea id={htmlId} value={value} onChange={(e) => onChange(e.target.value)} />
+      ) : kind === "number" ? (
+        <Input
+          id={htmlId}
+          type="number"
+          min={props.min}
+          max={props.max}
+          step={props.step}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      ) : kind === "enum" ? (
+        <select
+          id={htmlId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm"
+        >
+          {props.options.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <Input id={htmlId} value={value} onChange={(e) => onChange(e.target.value)} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/Inspector.tsx
+++ b/apps/web/src/components/Inspector.tsx
@@ -1,8 +1,7 @@
 import type { Block, PropertyDescriptor } from "@artefact-editor/core";
-import { Input } from "./ui/input.js";
-import { Textarea } from "./ui/textarea.js";
 import { Label } from "./ui/label.js";
 import { AssetPicker } from "./AssetPicker.js";
+import { FieldRow } from "./FieldRow.js";
 
 interface InspectorProps {
   projectId: string;
@@ -13,7 +12,33 @@ interface InspectorProps {
   onChange: (key: string, value: string | number) => void;
 }
 
-type StyleField = { key: string; label: string; type: "color" | "text" };
+type StyleKey =
+  | "color"
+  | "font-size"
+  | "font-weight"
+  | "font-family"
+  | "text-align"
+  | "letter-spacing"
+  | "line-height"
+  | "top"
+  | "left"
+  | "right"
+  | "bottom"
+  | "z-index"
+  | "width"
+  | "height"
+  | "margin-top"
+  | "margin-right"
+  | "margin-bottom"
+  | "margin-left"
+  | "padding-top"
+  | "padding-right"
+  | "padding-bottom"
+  | "padding-left"
+  | "transform"
+  | "opacity";
+
+type StyleField = { key: StyleKey; label: string; type: "color" | "text" };
 type StyleGroup = { title: string; fields: StyleField[] };
 
 const STYLE_GROUPS: StyleGroup[] = [
@@ -129,30 +154,14 @@ export function Inspector({ projectId, block, values, styles, assets, onChange }
                   const live = f.type === "color" ? rgbToHex(liveRaw) : liveRaw;
                   const current = pending !== undefined ? String(pending) : live;
                   return (
-                    <div key={f.key} className="space-y-1.5">
-                      <Label htmlFor={overrideKey}>{f.label}</Label>
-                      {f.type === "color" ? (
-                        <div className="flex items-center gap-2">
-                          <input
-                            type="color"
-                            value={/^#[0-9a-fA-F]{6,8}$/.test(current) ? current : "#000000"}
-                            onChange={(e) => onChange(overrideKey, e.target.value)}
-                            className="h-9 w-12 cursor-pointer rounded border border-border bg-background"
-                          />
-                          <Input
-                            id={overrideKey}
-                            value={current}
-                            onChange={(e) => onChange(overrideKey, e.target.value)}
-                          />
-                        </div>
-                      ) : (
-                        <Input
-                          id={overrideKey}
-                          value={current}
-                          onChange={(e) => onChange(overrideKey, e.target.value)}
-                        />
-                      )}
-                    </div>
+                    <FieldRow
+                      key={f.key}
+                      kind={f.type}
+                      htmlId={overrideKey}
+                      label={f.label}
+                      value={current}
+                      onChange={(v) => onChange(overrideKey, v)}
+                    />
                   );
                 })}
               </div>
@@ -172,54 +181,6 @@ interface DescriptorFieldProps {
 }
 
 function DescriptorField({ projectId, descriptor, value, assets, onChange }: DescriptorFieldProps) {
-  if (descriptor.type === "string") {
-    if (descriptor.multiline) {
-      return (
-        <div className="space-y-1.5">
-          <Label htmlFor={descriptor.key}>{descriptor.key}</Label>
-          <Textarea
-            id={descriptor.key}
-            value={String(value)}
-            onChange={(e) => onChange(e.target.value)}
-          />
-        </div>
-      );
-    }
-    return (
-      <div className="space-y-1.5">
-        <Label htmlFor={descriptor.key}>{descriptor.key}</Label>
-        <Input
-          id={descriptor.key}
-          value={String(value)}
-          onChange={(e) => onChange(e.target.value)}
-        />
-      </div>
-    );
-  }
-
-  if (descriptor.type === "color") {
-    const colorVal = String(value).trim() || "#000000";
-    const isHex = /^#[0-9a-fA-F]{3,8}$/.test(colorVal);
-    return (
-      <div className="space-y-1.5">
-        <Label htmlFor={descriptor.key}>{descriptor.key}</Label>
-        <div className="flex items-center gap-2">
-          <input
-            type="color"
-            value={isHex ? colorVal : "#000000"}
-            onChange={(e) => onChange(e.target.value)}
-            className="h-9 w-12 cursor-pointer rounded border border-border bg-background"
-          />
-          <Input
-            id={descriptor.key}
-            value={String(value)}
-            onChange={(e) => onChange(e.target.value)}
-          />
-        </div>
-      </div>
-    );
-  }
-
   if (descriptor.type === "asset") {
     return (
       <div className="space-y-1.5">
@@ -229,40 +190,55 @@ function DescriptorField({ projectId, descriptor, value, assets, onChange }: Des
     );
   }
 
+  if (descriptor.type === "string") {
+    return (
+      <FieldRow
+        kind={descriptor.multiline ? "textarea" : "text"}
+        htmlId={descriptor.key}
+        label={descriptor.key}
+        value={String(value)}
+        onChange={onChange}
+      />
+    );
+  }
+
+  if (descriptor.type === "color") {
+    return (
+      <FieldRow
+        kind="color"
+        htmlId={descriptor.key}
+        label={descriptor.key}
+        value={String(value).trim() || "#000000"}
+        onChange={onChange}
+      />
+    );
+  }
+
   if (descriptor.type === "number") {
     return (
-      <div className="space-y-1.5">
-        <Label htmlFor={descriptor.key}>{descriptor.key}</Label>
-        <Input
-          id={descriptor.key}
-          type="number"
-          min={descriptor.min}
-          max={descriptor.max}
-          step={descriptor.step}
-          value={String(value)}
-          onChange={(e) => onChange(Number(e.target.value))}
-        />
-      </div>
+      <FieldRow
+        kind="number"
+        htmlId={descriptor.key}
+        label={descriptor.key}
+        value={String(value)}
+        onChange={(v) => onChange(Number(v))}
+        min={descriptor.min}
+        max={descriptor.max}
+        step={descriptor.step}
+      />
     );
   }
 
   if (descriptor.type === "enum") {
     return (
-      <div className="space-y-1.5">
-        <Label htmlFor={descriptor.key}>{descriptor.key}</Label>
-        <select
-          id={descriptor.key}
-          value={String(value)}
-          onChange={(e) => onChange(e.target.value)}
-          className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm"
-        >
-          {descriptor.options.map((opt) => (
-            <option key={opt} value={opt}>
-              {opt}
-            </option>
-          ))}
-        </select>
-      </div>
+      <FieldRow
+        kind="enum"
+        htmlId={descriptor.key}
+        label={descriptor.key}
+        value={String(value)}
+        onChange={onChange}
+        options={descriptor.options}
+      />
     );
   }
 

--- a/apps/web/src/components/Timeline.tsx
+++ b/apps/web/src/components/Timeline.tsx
@@ -38,17 +38,24 @@ function tIndexFromVarName(name: string): number | null {
   return m ? parseInt(m[1]!, 10) : null;
 }
 
-interface Row {
-  kind: "audio" | "timing" | "visibility";
-  block: Block;
-  // audio
-  start?: number;
-  duration?: number;
-  // timing
-  value?: number;
-  // visibility
-  visStart?: number;
-  visEnd?: number;
+type Row =
+  | { kind: "audio"; block: Block; start: number; duration: number }
+  | { kind: "timing"; block: Block; value: number }
+  | { kind: "visibility"; block: Block; visStart: number; visEnd: number };
+
+type RowVariant = "aud" | "timing" | "img" | "txt";
+
+const BADGE: Record<RowVariant, { label: string; className: string }> = {
+  aud: { label: "AUD", className: "bg-sky-100 text-sky-700" },
+  timing: { label: "T", className: "bg-amber-100 text-amber-700" },
+  img: { label: "IMG", className: "bg-purple-100 text-purple-700" },
+  txt: { label: "TXT", className: "bg-slate-100 text-slate-700" },
+};
+
+function rowVariant(row: Row): RowVariant {
+  if (row.kind === "audio") return "aud";
+  if (row.kind === "timing") return "timing";
+  return row.block.kind === "image" ? "img" : "txt";
 }
 
 export function Timeline({
@@ -206,15 +213,7 @@ function TrackRow({
   onSetProperty,
 }: TrackRowProps) {
   const top = RULER_HEIGHT + rowIndex * LANE_HEIGHT;
-  const kindBadge = row.kind === "audio" ? "AUD" : row.kind === "timing" ? "T" : row.block.kind === "image" ? "IMG" : "TXT";
-  const badgeColor =
-    row.kind === "audio"
-      ? "bg-sky-100 text-sky-700"
-      : row.kind === "timing"
-        ? "bg-amber-100 text-amber-700"
-        : row.block.kind === "image"
-          ? "bg-purple-100 text-purple-700"
-          : "bg-slate-100 text-slate-700";
+  const badge = BADGE[rowVariant(row)];
 
   return (
     <>
@@ -228,9 +227,9 @@ function TrackRow({
         style={{ top, height: LANE_HEIGHT, width: TRACK_HEADER_W }}
       >
         <span
-          className={`shrink-0 rounded px-1 py-[1px] text-[9px] font-bold uppercase ${badgeColor}`}
+          className={`shrink-0 rounded px-1 py-[1px] text-[9px] font-bold uppercase ${badge.className}`}
         >
-          {kindBadge}
+          {badge.label}
         </span>
         <span className="truncate" title={row.block.label}>
           {row.block.label}
@@ -251,8 +250,8 @@ function TrackRow({
       {row.kind === "audio" ? (
         <AudioBar
           top={top}
-          start={row.start!}
-          duration={row.duration!}
+          start={row.start}
+          duration={row.duration}
           pxPerSec={pxPerSec}
           selected={selected}
           onSelect={onSelect}
@@ -266,7 +265,7 @@ function TrackRow({
       {row.kind === "timing" ? (
         <TimingMark
           top={top}
-          value={row.value!}
+          value={row.value}
           pxPerSec={pxPerSec}
           selected={selected}
           label={row.block.label}
@@ -277,8 +276,8 @@ function TrackRow({
       {row.kind === "visibility" ? (
         <VisibilityBar
           top={top}
-          start={row.visStart!}
-          end={Math.min(row.visEnd!, compositionDuration)}
+          start={row.visStart}
+          end={Math.min(row.visEnd, compositionDuration)}
           pxPerSec={pxPerSec}
           selected={selected}
           onSelect={onSelect}


### PR DESCRIPTION
## Summary

- New `FieldRow` component owns the Label + (Input | Textarea | color pair | number | enum select) shell. Inspector's style-group loop and `DescriptorField` branches both call it — ~80 lines of near-identical Label/Input markup collapses into one definition.
- Timeline `Row` is now a discriminated union on `kind`, eliminating the all-optional shape and the `!` non-null assertions at use sites.
- Replaced the 3-deep `kindBadge`/`badgeColor` ternaries with a single `rowVariant()` derivation and a `BADGE` lookup map.
- Typed Inspector's `STYLE_GROUPS` keys as a literal union (`StyleKey`) so a typo in a CSS property fails at compile time.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `yarn build:web` succeeds
- [x] Browser regression on hyperframes project: blocks list / timeline tracks / TXT badges / Inspector typography fields all render identically; no console errors

Closes #8.