### PR TITLE
Comment-and-apply loop: leave NL notes on blocks, generate agent prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage
 examples/*/output.png
 examples/*/output.png.layout.json
 examples/*/renders/editor-render.mp4
+examples/*/comments.json
 .gitnexus
 .claude/
 .code-audit-cache.json

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@artefact-editor/adapter-html": "0.1.0",
     "@artefact-editor/adapter-image-template": "0.1.0",
+    "@artefact-editor/contract": "0.1.0",
     "@artefact-editor/core": "0.1.0",
     "@hono/node-server": "^1.13.7",
     "hono": "^4.6.10"

--- a/apps/cli/src/comments.ts
+++ b/apps/cli/src/comments.ts
@@ -1,0 +1,149 @@
+import { randomUUID } from "node:crypto";
+import type { Block, Comment, ProjectFiles } from "@artefact-editor/core";
+
+const COMMENTS_FILE = "comments.json";
+
+interface CommentsFile {
+  version: 1;
+  comments: Comment[];
+}
+
+export async function readComments(files: ProjectFiles): Promise<Comment[]> {
+  if (!(await files.exists(COMMENTS_FILE))) return [];
+  try {
+    const raw = await files.read(COMMENTS_FILE);
+    const parsed = JSON.parse(raw) as CommentsFile | { comments?: Comment[] };
+    return parsed.comments ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export async function writeComments(files: ProjectFiles, comments: Comment[]): Promise<void> {
+  const data: CommentsFile = { version: 1, comments };
+  await files.write(COMMENTS_FILE, JSON.stringify(data, null, 2) + "\n");
+}
+
+export async function addComment(
+  files: ProjectFiles,
+  blockId: string,
+  text: string,
+): Promise<Comment> {
+  const comments = await readComments(files);
+  const comment: Comment = {
+    id: randomUUID(),
+    blockId,
+    text,
+    createdAt: new Date().toISOString(),
+    status: "pending",
+  };
+  comments.push(comment);
+  await writeComments(files, comments);
+  return comment;
+}
+
+export async function deleteComment(files: ProjectFiles, commentId: string): Promise<boolean> {
+  const comments = await readComments(files);
+  const next = comments.filter((c) => c.id !== commentId);
+  if (next.length === comments.length) return false;
+  await writeComments(files, next);
+  return true;
+}
+
+/**
+ * Build the prompt that would be sent to an agent to apply pending comments.
+ *
+ * The shape matters more than the wording today — host apps will tune this
+ * once we plug in a real agent loop. The current shape lists each comment
+ * with the block it targets and the block's current value, then a flat list
+ * of source files the agent would have access to. The "byte-identical except
+ * for changed fields" rule is repeated explicitly to discourage stylistic
+ * rewrites.
+ */
+export function buildApplyPrompt(args: {
+  projectName: string;
+  artefact: string;
+  blocks: Block[];
+  comments: Comment[];
+  sourceFiles: string[];
+}): string {
+  const { projectName, artefact, blocks, comments, sourceFiles } = args;
+  const blockById = new Map(blocks.map((b) => [b.id, b]));
+  const lines: string[] = [];
+  lines.push(
+    `You are editing the ${artefact} artefact "${projectName}". The user has left these comments`,
+    `on specific blocks. Apply each comment by editing the source files.`,
+    "",
+  );
+  for (const c of comments) {
+    const block = blockById.get(c.blockId);
+    if (!block) continue;
+    const sourceDesc = describeSource(block);
+    const currentDesc = describeCurrentValue(block);
+    lines.push(`Block: ${block.id} (kind=${block.kind}, source=${sourceDesc})`);
+    lines.push(`Label: ${block.label}`);
+    if (currentDesc) lines.push(`Current: ${currentDesc}`);
+    lines.push(`Comment: ${c.text}`);
+    lines.push("");
+  }
+  lines.push("Source files:");
+  for (const f of sourceFiles) lines.push(`- ${f}`);
+  lines.push("");
+  lines.push(
+    "After making changes, leave the source files byte-identical except for the",
+    "fields the comments asked you to change. Do not reformat unrelated code.",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Source files the agent would touch for a project. Manifest, entry, optional
+ * spec.json, plus everything under assets/. We deliberately don't enumerate
+ * the whole project tree — comments target individual blocks and the blocks
+ * already point at their source files, so this list is descriptive context
+ * rather than a sandbox boundary.
+ */
+export async function listSourceFiles(
+  files: ProjectFiles,
+  opts: { entry: string; specFile?: string; artefact: string; blocks: Block[] },
+): Promise<string[]> {
+  const out = new Set<string>(["manifest.json", opts.entry]);
+  if (opts.specFile) out.add(opts.specFile);
+  if (opts.artefact === "image-template") out.add("spec.json");
+  // Include any file referenced by a block's source (eg. styles.css for
+  // a cssVar block) so the agent has the complete edit surface.
+  for (const b of opts.blocks) {
+    if (b.source.file) out.add(b.source.file);
+  }
+  try {
+    const assets = await files.list("assets");
+    for (const a of assets) out.add(`assets/${a}`);
+  } catch {
+    // no assets dir
+  }
+  return Array.from(out).sort();
+}
+
+function describeSource(block: Block): string {
+  switch (block.source.tag) {
+    case "selector":
+      return `${block.source.file} ${block.source.selector}`;
+    case "cssVar":
+      return `${block.source.file} ${block.source.cssVar}`;
+    case "astVar":
+      return `${block.source.file} ${block.source.varName}`;
+    case "specKey":
+      return `${block.source.file}#${block.source.specKey}`;
+  }
+}
+
+function describeCurrentValue(block: Block): string | null {
+  // Prefer the canonical first descriptor's value (matches how
+  // adapter-image-template treats canonical keys, and how html-app blocks
+  // typically have a single "text"/"src"/"value" property).
+  const desc = block.descriptors.find((d) => d.canonical) ?? block.descriptors[0];
+  if (!desc) return null;
+  const value = block.values[desc.key];
+  if (value === undefined || value === "") return null;
+  return `${desc.key}=${JSON.stringify(value)}`;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -11,6 +11,14 @@ import { imageTemplateAdapter, SPEC_FILE_DEFAULT } from "@artefact-editor/adapte
 import { FsProjectFiles } from "./projectFiles.js";
 import { isInside } from "./paths.js";
 import { runChild } from "./runChild.js";
+import {
+  addComment,
+  buildApplyPrompt,
+  deleteComment,
+  listSourceFiles,
+  readComments,
+} from "./comments.js";
+import { createCommentRequestSchema } from "@artefact-editor/contract";
 
 const PYTHON_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_.]*$/;
 
@@ -366,6 +374,63 @@ app.get("/api/projects/:id/assets", async (c) => {
   const list = await p.files.list("assets");
   const allowed = list.filter((f) => /\.(png|jpe?g|gif|webp|svg|avif)$/i.test(f));
   return c.json({ assets: allowed.map((f) => `assets/${f}`) });
+});
+
+app.get("/api/projects/:id/comments", async (c) => {
+  const id = c.req.param("id");
+  const p = projects.get(id);
+  if (!p) return c.json({ comments: [] }, 404);
+  const comments = await readComments(p.files);
+  return c.json({ comments });
+});
+
+app.post("/api/projects/:id/comments", async (c) => {
+  const id = c.req.param("id");
+  const p = projects.get(id);
+  if (!p) return c.json({ error: "not found" }, 404);
+  const parse = createCommentRequestSchema.safeParse(await c.req.json());
+  if (!parse.success) return c.json({ error: parse.error.message }, 400);
+  const knownIds = new Set(p.blocks.map((b) => b.id));
+  if (!knownIds.has(parse.data.blockId)) {
+    return c.json({ error: `unknown blockId: ${parse.data.blockId}` }, 400);
+  }
+  const comment = await addComment(p.files, parse.data.blockId, parse.data.text);
+  return c.json({ comment });
+});
+
+app.delete("/api/projects/:id/comments/:commentId", async (c) => {
+  const id = c.req.param("id");
+  const commentId = c.req.param("commentId");
+  const p = projects.get(id);
+  if (!p) return c.json({ ok: false, error: "not found" }, 404);
+  const ok = await deleteComment(p.files, commentId);
+  if (!ok) return c.json({ ok: false, error: "comment not found" }, 404);
+  return c.json({ ok: true });
+});
+
+app.post("/api/projects/:id/comments/apply", async (c) => {
+  const id = c.req.param("id");
+  const p = projects.get(id);
+  if (!p) return c.json({ ok: false, error: "not found" }, 404);
+  const all = await readComments(p.files);
+  const pending = all.filter((cm) => cm.status === "pending");
+  if (pending.length === 0) {
+    return c.json({ ok: false, error: "no pending comments", prompt: "", comments: [], sourceFiles: [] });
+  }
+  const sourceFiles = await listSourceFiles(p.files, {
+    entry: p.entry,
+    specFile: p.manifest?.specFile,
+    artefact: p.manifest?.artefact ?? "html-app",
+    blocks: p.blocks,
+  });
+  const prompt = buildApplyPrompt({
+    projectName: p.name,
+    artefact: p.manifest?.artefact ?? "html-app",
+    blocks: p.blocks,
+    comments: pending,
+    sourceFiles,
+  });
+  return c.json({ ok: true, prompt, comments: pending, sourceFiles });
 });
 
 const MIME: Record<string, string> = {

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
-import type { Block } from "@artefact-editor/core";
+import type { Block, Comment } from "@artefact-editor/core";
+
+export type { Comment, CommentStatus } from "@artefact-editor/core";
 
 /**
  * Wire schemas for the artefact-editor HTTP API.
@@ -90,4 +92,32 @@ export interface ImageLayout {
   width: number;
   height: number;
   regions: ImageRegion[];
+}
+
+export const createCommentRequestSchema = z.object({
+  blockId: z.string(),
+  text: z.string().min(1).max(2000),
+});
+export type CreateCommentRequest = z.infer<typeof createCommentRequestSchema>;
+
+export interface ListCommentsResponse {
+  comments: Comment[];
+}
+
+export interface CreateCommentResponse {
+  comment: Comment;
+}
+
+export interface DeleteCommentResponse {
+  ok: boolean;
+}
+
+export interface ApplyCommentsResponse {
+  ok: boolean;
+  /** Generated prompt that would be sent to an agent. Dry-run for now. */
+  prompt: string;
+  comments: Comment[];
+  /** Source files the agent would have access to. Project-root-relative. */
+  sourceFiles: string[];
+  error?: string;
 }

--- a/packages/core/src/comment.ts
+++ b/packages/core/src/comment.ts
@@ -1,0 +1,9 @@
+export type CommentStatus = "pending" | "applied" | "dismissed";
+
+export interface Comment {
+  id: string;
+  blockId: string;
+  text: string;
+  createdAt: string;
+  status: CommentStatus;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export type { Block, BlockId, BlockKind, SourceRef } from "./block.js";
 export type { PropertyDescriptor, PropertyValue } from "./descriptor.js";
 export type { Command } from "./commands.js";
+export type { Comment, CommentStatus } from "./comment.js";
 export type { Adapter, ProjectFiles } from "./adapter.js";
 export { Doc, type DocSnapshot } from "./doc.js";
 export { manifestSchema, parseManifest, type Manifest, type ManifestBlock } from "./manifest.js";

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -67,15 +67,19 @@ The `content` glob pointing at the editor's compiled JS is required — without 
 
 The editor expects these endpoints under `apiUrl` / `previewUrl`. Schemas are exported from `@artefact-editor/contract`.
 
-| Method | Path                              | Request body         | Response                  |
-| ------ | --------------------------------- | -------------------- | ------------------------- |
-| GET    | `{apiUrl}/projects`               | —                    | `ListProjectsResponse`    |
-| GET    | `{apiUrl}/projects/:id`           | —                    | `GetProjectResponse`      |
-| POST   | `{apiUrl}/projects/:id/save`      | `SaveRequest`        | `SaveResponse`            |
-| POST   | `{apiUrl}/projects/:id/render`    | —                    | `RenderResponse`          |
-| GET    | `{apiUrl}/projects/:id/assets`    | —                    | `ListAssetsResponse`      |
-| GET    | `{apiUrl}/projects/:id/archive`   | —                    | `application/zip` stream  |
-| GET    | `{previewUrl}/:id/<path>`         | —                    | static file (entry, rendered output, assets, layout sidecar) |
+| Method | Path                                              | Request body            | Response                  |
+| ------ | ------------------------------------------------- | ----------------------- | ------------------------- |
+| GET    | `{apiUrl}/projects`                               | —                       | `ListProjectsResponse`    |
+| GET    | `{apiUrl}/projects/:id`                           | —                       | `GetProjectResponse`      |
+| POST   | `{apiUrl}/projects/:id/save`                      | `SaveRequest`           | `SaveResponse`            |
+| POST   | `{apiUrl}/projects/:id/render`                    | —                       | `RenderResponse`          |
+| GET    | `{apiUrl}/projects/:id/assets`                    | —                       | `ListAssetsResponse`      |
+| GET    | `{apiUrl}/projects/:id/archive`                   | —                       | `application/zip` stream  |
+| GET    | `{apiUrl}/projects/:id/comments`                  | —                       | `ListCommentsResponse`    |
+| POST   | `{apiUrl}/projects/:id/comments`                  | `CreateCommentRequest`  | `CreateCommentResponse`   |
+| DELETE | `{apiUrl}/projects/:id/comments/:commentId`       | —                       | `DeleteCommentResponse`   |
+| POST   | `{apiUrl}/projects/:id/comments/apply`            | —                       | `ApplyCommentsResponse`   |
+| GET    | `{previewUrl}/:id/<path>`                         | —                       | static file (entry, rendered output, assets, layout sidecar) |
 
 A minimal Hono handler validating saves against the contract:
 
@@ -96,6 +100,12 @@ app.post("/api/projects/:id/save", async (c) => {
 ```
 
 The reference implementation lives in [`apps/cli/src/index.ts`](../../apps/cli/src/index.ts) — it backs the contract with the local filesystem and the bundled adapters (`@artefact-editor/adapter-html`, `@artefact-editor/adapter-image-template`). Reuse those adapters if your storage exposes a `ProjectFiles`-shaped interface; implement the contract directly otherwise.
+
+## Comment-and-apply loop
+
+The editor has a comment mode (toggle via the **Comment** button in the top bar or the `c` key) that lets users leave plain-English notes on individual blocks instead of editing them directly. Comments queue up in a side panel; clicking **Apply** calls `POST /comments/apply`, which returns a generated prompt describing the edits the agent should make.
+
+For now `apply` is a **dry run** — it returns the prompt but does not invoke an agent. The intended host integration is to forward the prompt (plus the listed source files) to the Claude Agent SDK or equivalent and surface the agent's edits back to the user. Comment status (`pending` → `applied` / `dismissed`) is in the schema for that future flow.
 
 ## What's not in this package
 

--- a/packages/editor/src/ArtefactEditor.tsx
+++ b/packages/editor/src/ArtefactEditor.tsx
@@ -1,15 +1,20 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { ApplyCommentsResponse } from "@artefact-editor/contract";
 import { useDoc, getEffectiveValue } from "./hooks/useDoc.js";
 import { useElementStyles } from "./hooks/useElementStyles.js";
 import { useSelection } from "./hooks/useSelection.js";
 import { useTransport } from "./hooks/useTransport.js";
 import { useProjectAssets } from "./hooks/useProjectAssets.js";
 import { useImageLayout } from "./hooks/useImageLayout.js";
+import { useComments } from "./hooks/useComments.js";
 import { Inspector } from "./components/Inspector.js";
 import { PreviewFrame } from "./components/PreviewFrame.js";
 import { Timeline } from "./components/Timeline.js";
 import { TopBar } from "./components/TopBar.js";
 import { TransportBar } from "./components/TransportBar.js";
+import { CommentsPanel } from "./components/CommentsPanel.js";
+import { CommentComposer } from "./components/CommentComposer.js";
+import { ApplyCommentsModal } from "./components/ApplyCommentsModal.js";
 import {
   EditorConfigContext,
   apiPath,
@@ -61,6 +66,19 @@ function ArtefactEditorInner({ projectId, onBack }: ArtefactEditorInnerProps) {
   const isWebApp = state.artefact === "html-app";
   const { assets } = useProjectAssets(projectId);
   const { layout } = useImageLayout(projectId, state.entry, state.bumpKey, isImageTemplate);
+  const comments = useComments(projectId);
+  const [commentMode, setCommentMode] = useState(false);
+  const [applyResult, setApplyResult] = useState<ApplyCommentsResponse | null>(null);
+  const [applying, setApplying] = useState(false);
+  const pendingComments = useMemo(
+    () => comments.comments.filter((c) => c.status === "pending"),
+    [comments.comments],
+  );
+  const pendingByBlock = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const c of pendingComments) m.set(c.blockId, (m.get(c.blockId) ?? 0) + 1);
+    return m;
+  }, [pendingComments]);
   // hyperframes → scaled iframe + transport + timeline (even if a particular
   // composition has no audio/timing blocks, it's still a fixed-size video).
   // html-app → fill the pane, no transport.
@@ -106,11 +124,26 @@ function ArtefactEditorInner({ projectId, onBack }: ArtefactEditorInnerProps) {
           e.preventDefault();
           h.transport.toggle();
         }
+      } else if (e.key === "c" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const tag = (e.target as HTMLElement | null)?.tagName;
+        if (tag !== "INPUT" && tag !== "TEXTAREA") {
+          setCommentMode((m) => !m);
+        }
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, []);
+
+  const onApplyComments = async () => {
+    setApplying(true);
+    try {
+      const r = await comments.apply();
+      if (r && r.ok) setApplyResult(r);
+    } finally {
+      setApplying(false);
+    }
+  };
 
   const valuesForSelected = useMemo(() => {
     if (!selectedBlock) return {};
@@ -165,6 +198,9 @@ function ArtefactEditorInner({ projectId, onBack }: ArtefactEditorInnerProps) {
           window.location.assign(apiPath(config, `/projects/${projectId}/archive`));
         }}
         onBack={onBack}
+        commentMode={commentMode}
+        onToggleCommentMode={() => setCommentMode((m) => !m)}
+        pendingCommentCount={pendingComments.length}
       />
       <div className="flex min-h-0 flex-1">
         <aside className="flex w-72 flex-col border-r border-border">
@@ -175,6 +211,7 @@ function ArtefactEditorInner({ projectId, onBack }: ArtefactEditorInnerProps) {
             {state.blocks.map((b) => {
               const isPending = state.pendingValues.has(b.id);
               const isSelected = b.id === selectedBlockId;
+              const commentCount = pendingByBlock.get(b.id) ?? 0;
               return (
                 <button
                   type="button"
@@ -191,12 +228,32 @@ function ArtefactEditorInner({ projectId, onBack }: ArtefactEditorInnerProps) {
                     </span>
                     <span className="ml-2">{b.label}</span>
                   </span>
-                  {isPending ? (
-                    <span className="ml-2 inline-block h-1.5 w-1.5 rounded-full bg-amber-500" />
-                  ) : null}
+                  <span className="ml-2 flex items-center gap-1.5">
+                    {commentCount > 0 ? (
+                      <span className="rounded bg-primary/10 px-1.5 text-[10px] font-medium text-primary">
+                        {commentCount}
+                      </span>
+                    ) : null}
+                    {isPending ? (
+                      <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500" />
+                    ) : null}
+                  </span>
                 </button>
               );
             })}
+          </div>
+          <div className="border-t border-border px-4 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Comments
+          </div>
+          <div className="max-h-72 overflow-auto">
+            <CommentsPanel
+              comments={comments.comments}
+              blocks={state.blocks}
+              onSelectBlock={setSelectedBlockId}
+              onDelete={(id) => void comments.remove(id)}
+              onApply={() => void onApplyComments()}
+              applying={applying}
+            />
           </div>
         </aside>
         <main className="relative flex min-w-0 flex-1 flex-col bg-muted">
@@ -252,6 +309,18 @@ function ArtefactEditorInner({ projectId, onBack }: ArtefactEditorInnerProps) {
           )}
         </main>
         <aside className="w-80 overflow-auto border-l border-border">
+          {commentMode && selectedBlock ? (
+            <div className="p-4">
+              <CommentComposer
+                blockLabel={selectedBlock.label}
+                blockId={selectedBlock.id}
+                onSubmit={async (text) => {
+                  await comments.add(selectedBlock.id, text);
+                }}
+                onCancel={() => setCommentMode(false)}
+              />
+            </div>
+          ) : null}
           <Inspector
             projectId={projectId}
             block={selectedBlock}
@@ -264,6 +333,9 @@ function ArtefactEditorInner({ projectId, onBack }: ArtefactEditorInnerProps) {
           />
         </aside>
       </div>
+      {applyResult ? (
+        <ApplyCommentsModal result={applyResult} onClose={() => setApplyResult(null)} />
+      ) : null}
     </div>
   );
 }

--- a/packages/editor/src/components/ApplyCommentsModal.tsx
+++ b/packages/editor/src/components/ApplyCommentsModal.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import type { ApplyCommentsResponse } from "@artefact-editor/contract";
+import { Button } from "./ui/button.js";
+
+interface ApplyCommentsModalProps {
+  result: ApplyCommentsResponse;
+  onClose: () => void;
+}
+
+export function ApplyCommentsModal({ result, onClose }: ApplyCommentsModalProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(result.prompt);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-30 flex items-center justify-center bg-black/40 p-6"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[80vh] w-full max-w-2xl flex-col gap-3 rounded-lg border border-border bg-background p-4 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-baseline justify-between">
+          <h2 className="text-sm font-semibold">Apply comments — generated prompt</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            ×
+          </button>
+        </header>
+        <p className="text-xs text-muted-foreground">
+          Dry run — agent integration is not wired yet. Copy this prompt into Claude / your
+          agent of choice and run it against the project root.
+        </p>
+        <pre className="flex-1 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-muted px-3 py-2 font-mono text-[11px] leading-relaxed">
+          {result.prompt}
+        </pre>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={onClose}>
+            Close
+          </Button>
+          <Button size="sm" onClick={() => void copy()}>
+            {copied ? "Copied" : "Copy prompt"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/editor/src/components/CommentComposer.tsx
+++ b/packages/editor/src/components/CommentComposer.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from "react";
+import { Button } from "./ui/button.js";
+import { Textarea } from "./ui/textarea.js";
+
+interface CommentComposerProps {
+  blockLabel: string;
+  blockId: string;
+  onSubmit: (text: string) => Promise<void> | void;
+  onCancel: () => void;
+}
+
+export function CommentComposer({ blockLabel, blockId, onSubmit, onCancel }: CommentComposerProps) {
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  const submit = async () => {
+    const trimmed = text.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(trimmed);
+      setText("");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2 rounded-md border border-border bg-background p-3 shadow-sm">
+      <div className="flex items-baseline justify-between">
+        <div className="text-xs font-semibold">Comment on {blockLabel}</div>
+        <div className="font-mono text-[10px] text-muted-foreground">{blockId}</div>
+      </div>
+      <Textarea
+        ref={ref}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={3}
+        placeholder="e.g. punchier, mention the 14-day trial"
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            void submit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+      />
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button size="sm" disabled={!text.trim() || submitting} onClick={() => void submit()}>
+          {submitting ? "Saving…" : "Add comment"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/editor/src/components/CommentsPanel.tsx
+++ b/packages/editor/src/components/CommentsPanel.tsx
@@ -1,0 +1,70 @@
+import type { Block, Comment } from "@artefact-editor/core";
+import { Button } from "./ui/button.js";
+
+interface CommentsPanelProps {
+  comments: Comment[];
+  blocks: Block[];
+  onSelectBlock: (blockId: string) => void;
+  onDelete: (commentId: string) => void;
+  onApply: () => void;
+  applying?: boolean;
+}
+
+export function CommentsPanel({
+  comments,
+  blocks,
+  onSelectBlock,
+  onDelete,
+  onApply,
+  applying,
+}: CommentsPanelProps) {
+  const pending = comments.filter((c) => c.status === "pending");
+  const blocksById = new Map(blocks.map((b) => [b.id, b]));
+
+  if (pending.length === 0) {
+    return (
+      <div className="px-4 py-3 text-xs text-muted-foreground">
+        No comments. Toggle Comment mode and click a block in the preview to leave one.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 px-2 py-2">
+      {pending.map((c) => {
+        const block = blocksById.get(c.blockId);
+        return (
+          <div
+            key={c.id}
+            className="rounded-md border border-border bg-background px-3 py-2 text-xs"
+          >
+            <div className="flex items-baseline justify-between gap-2">
+              <button
+                type="button"
+                onClick={() => onSelectBlock(c.blockId)}
+                className="truncate font-semibold hover:underline"
+                title="Select this block"
+              >
+                {block?.label ?? c.blockId}
+              </button>
+              <button
+                type="button"
+                onClick={() => onDelete(c.id)}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Dismiss comment"
+              >
+                ×
+              </button>
+            </div>
+            <p className="mt-1 whitespace-pre-wrap text-foreground">{c.text}</p>
+          </div>
+        );
+      })}
+      <div className="px-1 pt-1">
+        <Button size="sm" className="w-full" onClick={onApply} disabled={applying}>
+          {applying ? "Generating…" : `Apply ${pending.length} comment${pending.length === 1 ? "" : "s"}`}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/editor/src/components/TopBar.tsx
+++ b/packages/editor/src/components/TopBar.tsx
@@ -1,4 +1,4 @@
-import { Download, Film, ImageIcon, Save } from "lucide-react";
+import { Download, Film, ImageIcon, MessageSquare, Save } from "lucide-react";
 import { Button } from "./ui/button.js";
 
 interface TopBarProps {
@@ -12,6 +12,9 @@ interface TopBarProps {
   renderKind?: "image" | "video";
   onDownload?: () => void;
   onBack?: () => void;
+  commentMode?: boolean;
+  onToggleCommentMode?: () => void;
+  pendingCommentCount?: number;
 }
 
 export function TopBar({
@@ -25,6 +28,9 @@ export function TopBar({
   renderKind = "image",
   onDownload,
   onBack,
+  commentMode,
+  onToggleCommentMode,
+  pendingCommentCount,
 }: TopBarProps) {
   const RenderIcon = renderKind === "video" ? Film : ImageIcon;
   const renderLabel = renderKind === "video" ? "Render MP4" : "Render";
@@ -51,6 +57,17 @@ export function TopBar({
         ) : null}
       </div>
       <div className="flex items-center gap-2">
+        {onToggleCommentMode ? (
+          <Button
+            onClick={onToggleCommentMode}
+            size="sm"
+            variant={commentMode ? "default" : "ghost"}
+            title={commentMode ? "Exit comment mode (c)" : "Enter comment mode (c)"}
+          >
+            <MessageSquare className="h-3.5 w-3.5" />
+            Comment{pendingCommentCount ? ` (${pendingCommentCount})` : ""}
+          </Button>
+        ) : null}
         {onDownload ? (
           <Button onClick={onDownload} size="sm" variant="ghost" title="Download .artefact archive">
             <Download className="h-3.5 w-3.5" />

--- a/packages/editor/src/hooks/useComments.ts
+++ b/packages/editor/src/hooks/useComments.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from "react";
+import type {
+  ApplyCommentsResponse,
+  Comment,
+  CreateCommentResponse,
+  ListCommentsResponse,
+} from "@artefact-editor/contract";
+import { apiPath, useEditorConfig } from "../config.js";
+
+export interface UseCommentsApi {
+  comments: Comment[];
+  loading: boolean;
+  error: string | null;
+  add: (blockId: string, text: string) => Promise<Comment | null>;
+  remove: (commentId: string) => Promise<void>;
+  apply: () => Promise<ApplyCommentsResponse | null>;
+  reload: () => Promise<void>;
+}
+
+export function useComments(projectId: string): UseCommentsApi {
+  const config = useEditorConfig();
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(apiPath(config, `/projects/${projectId}/comments`));
+      const data = (await res.json()) as ListCommentsResponse;
+      setComments(data.comments ?? []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId, config]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const add = useCallback(
+    async (blockId: string, text: string): Promise<Comment | null> => {
+      try {
+        const res = await fetch(apiPath(config, `/projects/${projectId}/comments`), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ blockId, text }),
+        });
+        if (!res.ok) {
+          setError(`HTTP ${res.status}`);
+          return null;
+        }
+        const data = (await res.json()) as CreateCommentResponse;
+        setComments((prev) => [...prev, data.comment]);
+        return data.comment;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        return null;
+      }
+    },
+    [projectId, config],
+  );
+
+  const remove = useCallback(
+    async (commentId: string) => {
+      // Optimistic — drop locally first, restore on failure.
+      const prev = comments;
+      setComments((cs) => cs.filter((c) => c.id !== commentId));
+      try {
+        const res = await fetch(
+          apiPath(config, `/projects/${projectId}/comments/${commentId}`),
+          { method: "DELETE" },
+        );
+        if (!res.ok) {
+          setComments(prev);
+          setError(`HTTP ${res.status}`);
+        }
+      } catch (err) {
+        setComments(prev);
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [comments, projectId, config],
+  );
+
+  const apply = useCallback(async (): Promise<ApplyCommentsResponse | null> => {
+    try {
+      const res = await fetch(apiPath(config, `/projects/${projectId}/comments/apply`), {
+        method: "POST",
+      });
+      const data = (await res.json()) as ApplyCommentsResponse;
+      return data;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return null;
+    }
+  }, [projectId, config]);
+
+  return { comments, loading, error, add, remove, apply, reload };
+}


### PR DESCRIPTION
## Summary

Borrowed UX from [open-slide](https://x.com/1weiho/status/2050602481953181968): user toggles **Comment** mode (top-bar button or `c` key), clicks a block, leaves a plain-English note ("punchier", "make this warmer"). Notes queue in a sidebar panel; clicking **Apply** calls a new endpoint that returns the prompt an agent would use to apply them.

Closes the gap between direct manipulation (precise edits the user can express themselves) and re-prompting the agent (vague rewrites only the agent can do).

### Wire

- **core**: new `Comment` type (`id`, `blockId`, `text`, `createdAt`, `status`).
- **contract**: `createCommentRequestSchema` + 4 response interfaces.
- **cli**: filesystem-backed CRUD against `comments.json` next to manifest; `/apply` generates the prompt with per-block context + the full source-file surface. `comments.json` is gitignored.
- **editor**: `useComments` hook, `CommentsPanel` (left sidebar with apply button), `CommentComposer` (top of inspector when comment mode + block selected), `ApplyCommentsModal` (shows generated prompt with copy-to-clipboard).

### Dry-run today

`/apply` returns the prompt but **does not invoke an agent**. The intended host integration is to forward the prompt (plus the source-file list) to the Claude Agent SDK / equivalent and surface the agent's edits back. Comment status (`pending` → `applied`/`dismissed`) is in the schema for that future flow.

### Test plan

- [x] `yarn typecheck` clean
- [x] `yarn build` clean (web bundle ~211 kB precache)
- [x] POST `/comments` rejects unknown `blockId`
- [x] Comment round-trip: POST → GET lists it → DELETE removes it → file updates on disk
- [x] `/apply` generates a prompt with block IDs, labels, current values, and a source-file list that includes files referenced by `cssVar`/`astVar` blocks (e.g. `styles.css` for hero-landing)
- [x] dev-browser walkthrough: comment mode toggles via `c`, composer renders for selected block, sidebar panel shows pending comments, modal shows the prompt with copy button

### Out of scope (next PR)

- Real agent execution. Endpoint signature stays the same; response gains a structured edit summary.
- Comment status updates after apply (which succeeded, which were skipped).
- Pin overlays positioned over the preview iframe (deferred — non-trivial given iframe scaling + image-template/html-app split).