### PR TITLE
Fix save error handling + image style descriptors

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -189,7 +189,12 @@ app.post("/api/projects/:id/save", async (c) => {
   }
 
   const doc = new Doc(p.blocks.map((b) => ({ ...b, values: { ...b.values } })));
-  for (const cmd of body.commands) doc.apply(cmd);
+  try {
+    for (const cmd of body.commands) doc.apply(cmd);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ ok: false, error: message }, 400);
+  }
 
   // Net commands = touched (block, key) pairs whose final value differs from
   // the original. Tracking touched keys (rather than scanning every dirty
@@ -222,8 +227,13 @@ app.post("/api/projects/:id/save", async (c) => {
     return c.json({ ok: true, changed: 0 });
   }
 
-  await p.adapter.apply(p.files, p.blocks, settledCommands);
-  await reloadProject(id);
+  try {
+    await p.adapter.apply(p.files, p.blocks, settledCommands);
+    await reloadProject(id);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ ok: false, error: message }, 500);
+  }
   return c.json({ ok: true, changed: settledCommands.length });
 });
 

--- a/packages/adapter-html/src/load.ts
+++ b/packages/adapter-html/src/load.ts
@@ -146,7 +146,7 @@ export async function loadProject(files: ProjectFiles): Promise<{
       );
     }
     const descriptors: PropertyDescriptor[] = [...mb.properties];
-    if (mb.kind === "text" && "selector" in mb.source) {
+    if ((mb.kind === "text" || mb.kind === "image") && "selector" in mb.source) {
       // Synthetic style.* descriptors so the editor can show a Style section.
       // Live values are read from the iframe; pending edits flow through normal
       // setProperty commands and the adapter upserts them into the element's

--- a/packages/editor/src/hooks/useDoc.ts
+++ b/packages/editor/src/hooks/useDoc.ts
@@ -127,6 +127,10 @@ export function useDoc(projectId: string): UseDocApi {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ commands }),
       });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Save failed (${res.status}): ${text.slice(0, 200)}`);
+      }
       const data = (await res.json()) as SaveResponse;
       if (!data.ok) throw new Error(data.error ?? "Save failed");
     } catch (err) {


### PR DESCRIPTION
Three coupled bugs that surfaced as \`Failed to load project: Unexpected token 'I', \"Internal S\"... is not valid JSON\` when editing position/spacing on an image block.

1. \`adapter-html\` only loaded synthetic \`style.*\` descriptors for text blocks. After PR #26 the inspector exposes them on image blocks too, so a save crashed \`Doc.apply\` with \"Unknown property 'style.padding-top'\".
2. The save endpoint let the exception propagate to Hono's default handler, which returns plain-text \`Internal Server Error\`.
3. \`useDoc.save\` called \`res.json()\` without checking \`res.ok\`, so the non-JSON 500 body produced the cryptic parse error.

Fixes in three places: extend descriptors to image blocks, wrap save in try/catch returning JSON, check \`res.ok\` before \`.json()\`.